### PR TITLE
Adds table with columns and colgroups

### DIFF
--- a/kitchen-sink.html
+++ b/kitchen-sink.html
@@ -520,6 +520,81 @@ A leaflet.
           </tr>
         </tfoot>
       </table>
+      <table>
+        <caption>A Table with <code>col</code> and <code>colgroup</code> of proto-indo-europeans languages and words.</caption>
+          <col />
+        <colgroup>
+          <col />
+          <col />
+          <col />
+          <col />
+        </colgroup>
+        <colgroup>
+          <col />
+          <col />
+          <col />
+          <col />
+        </colgroup>
+        <thead>
+          <tr>
+            <td></td>
+            <th colspan="4" id="germanic">Germanic</th>
+            <th colspan="4" id="italic">Italic</th>
+          </tr>
+          <tr>
+            <td></td>
+            <th colspan="2" id="north-germanic" headers="germanic">North Germanic</th>
+            <th colspan="2" id="west-germanic" headers="germanic">West Germanic</th>
+            <th colspan="4" id="latin" headers="italic">Latin</th>
+          </tr>
+          <tr>
+            <th id="modern-english">Modern English</th>
+            <th id="old-norse" headers="north-germanic germanic">Old Norse</th>
+            <th id="swedish" headers="north-germanic germanic">Swedish</th>
+            <th id="old-english" headers="west-germanic germanic">Old English</th>
+            <th id="old-dutch" headers="west-germanic germanic">Old Dutch</th>
+            <th id="french" headers="latin italic">French</th>
+            <th id="spanish" headers="latin italic">Spanish</th>
+            <th id="portuguese" headers="latin italic">Portuguese</th>
+            <th id="catalan" headers="latin italic">Catalan</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th headers="modern-english" id="modern-english-no">No</th>
+            <td headers="modern-english-no germanic north-germanic old-norse">Nei</td>
+            <td headers="modern-english-no germanic north-germanic swedish">Nej</td>
+            <td headers="modern-english-no germanic west-germanic old-english">Ná</td>
+            <td headers="modern-english-no germanic west-germanic old-dutch">Nein</td>
+            <td headers="modern-english-no latin italic french">Non</td>
+            <td headers="modern-english-no latin italic spanish">No</td>
+            <td headers="modern-english-no latin italic portuguese">não</td>
+            <td headers="modern-english-no latin italic catalan">No</td>
+          </tr>
+          <tr>
+            <th headers="modern-english" id="modern-english-yes">Yes</th>
+            <td headers="modern-english-yes germanic north-germanic old-norse">já</td>
+            <td headers="modern-english-yes germanic north-germanic swedish">Ja</td>
+            <td headers="modern-english-yes germanic west-germanic old-english">Gea</td>
+            <td headers="modern-english-yes germanic west-germanic old-dutch">Ja</td>
+            <td headers="modern-english-yes latin italic french">Oui</td>
+            <td headers="modern-english-yes latin italic spanish">Si</td>
+            <td headers="modern-english-yes latin italic portuguese">sim</td>
+            <td headers="modern-english-yes latin italic catalan">sí</td>
+          </tr>
+          <tr>
+            <th headers="modern-english" id="modern-english-bear">Bear</th>
+            <td headers="modern-english-bear germanic north-germanic old-norse">Bjorn</td>
+            <td headers="modern-english-bear germanic north-germanic swedish">bjorn</td>
+            <td headers="modern-english-bear germanic west-germanic old-english">bera</td>
+            <td headers="modern-english-bear germanic west-germanic old-dutch">beer</td>
+            <td headers="modern-english-bear latin italic french">Ours</td>
+            <td headers="modern-english-bear latin italic spanish">Oso</td>
+            <td headers="modern-english-bear latin italic portuguese">Urso</td>
+            <td headers="modern-english-bear latin italic catalan">ós</td>
+          </tr>
+        </tbody>
+      </table>
       <footer>
         <p>See the <a target="_blank" href="https://www.w3.org/TR/html5/dom.html#palpable-content">Palpable
 Content spec.</a></p>


### PR DESCRIPTION
Howdy,

I looked through the different examples of tables that I had in my [table-baseline.css](https://github.com/paceaux/table-baseline) and noticed that I'd missed an example using `<col>` and `<colgroup>`.  I made an update to my own CSS baseline's test.html file, and this update is that exact same HTML. It also covers the complex use-case of multiple rows in a `thead` and row headers, too. 