### PR TITLE
Validate HTML

### DIFF
--- a/kitchen-sink.html
+++ b/kitchen-sink.html
@@ -15,18 +15,16 @@
   <hr>
   <main>
     <section id="headings">
-      <h3><a href="#headings">#</a> Headings </h3>
+      <h2><a href="#headings">#</a> Headings </h2>
       <p>Elements <code>h1</code>, <code>h2</code>, <code>h3</code>, <code>h4</code>,
         <code>h5</code>, <code>h6</code> make up the <em>heading content</em> category.
       </p>
-      <hgroup>
         <h1>h1 I am most important.</h1>
         <h2>h2 Back in my quaint <a href='#'>garden</a></h2>
         <h3>h3 Jaunty <a href='#'>zinnias</a> vie with flaunting phlox.</h3>
         <h4>h4 Five or six big jet planes zoomed quickly by the new tower.</h4>
         <h5>h5 Expect skilled signwriters to use many jazzy, quaint old alphabets effectively.</h5>
         <h6>h6 Pack my box with five dozen liquor jugs.</h6>
-      </hgroup>
       <footer>
         <p>See the <a target="_blank" href="https://www.w3.org/TR/html5/dom.html#heading-content">Heading Content spec.</a></p>
         <p>Note: these two paragraphs are contained in a <code>footer</code> element.
@@ -37,7 +35,7 @@
     <hr>
     <section id="sections">
       <header>
-        <h3><a href="#sections">#</a> Sections</h3>
+        <h2><a href="#sections">#</a> Sections</h2>
         <p>Elements <code>article</code>, <code>aside</code>, <code>nav</code>,
           <code>section</code> make up the <em>sectioning content</em> category.
         </p>
@@ -74,7 +72,7 @@ Content spec.</a></p>
     <hr>
     <section id="phrasing">
       <header>
-        <h3><a href="#phrasing">#</a> Phrasing</h3>
+        <h2><a href="#phrasing">#</a> Phrasing</h2>
         <p>Elements <code>abbr</code>, <code>b</code>, <code>bdi</code>,
           <code>bdo</code>, <code>br</code>, <code>cite</code>, <code>code</code>,
           <code>data</code>, <code>del</code>, <code>dfn</code>, <code>em</code>,
@@ -116,7 +114,7 @@ overridden.</bdo></p>
     <hr>
     <section id="palpable">
       <header>
-        <h3><a href="#palpable">#</a> Palpable Content</h3>
+        <h2><a href="#palpable">#</a> Palpable Content</h2>
         <p>Elements <code>a</code>, <code>address</code>, <code>blockquote</code>,
           <code>button</code>, <code>details</code>, <code>dl</code>, <code>fieldset</code>,
           <code>figure</code>, <code>form</code>, <code>input</code>, <code>label</code>,
@@ -175,7 +173,7 @@ United States
 
       <br>
       <hr>
-      <h4 id="forms"><a href="#forms">#</a> Forms</h4>
+      <h3 id="forms"><a href="#forms">#</a> Forms</h3>
       <form>
         <p>
           <label for="example-input-email">Email address</label>
@@ -220,10 +218,6 @@ United States
         <p>
           <label for="example-input-date">Date</label>
           <input type="date" id="example-input-date">
-        </p>
-        <p>
-          <label for="example-input-date-time">Date / Time</label>
-          <input type="datetime" id="example-input-date-time">
         </p>
         <p>
           <label for="example-input-date-time-local">Date / Time local</label>
@@ -440,7 +434,7 @@ A leaflet.
 
       <br>
       <hr>
-      <h4 id="tables"><a href="#tables">#</a> Tables</h4>
+      <h3 id="tables"><a href="#tables">#</a> Tables</h3>
       <table>
         <caption>Tables can have captions now.</caption>
         <tbody>
@@ -619,7 +613,7 @@ Content spec.</a></p>
     <hr>
     <section id="embeds">
       <header>
-        <h3><a href="#embeds">#</a> Embeds</h3>
+        <h2><a href="#embeds">#</a> Embeds</h2>
         <p>Elements <code>audio</code>, <code>canvas</code>, <code>embed</code>,
           <code>iframe</code>, <code>img</code>, <code>math</code>, <code>object</code>,
           <code>picture</code>, <code>svg</code>, <code>video</code> make up the <em>embedded content</em> category.</p>


### PR DESCRIPTION
This corrects a few HTML errors reported by <https://validator.w3.org/>, namely:

- Incorrectly nested headers (h3 under h1, etc.)
- Misuse of hgroup (should contain only one h element)
- Presence of `input` with `type=datetime` which is now deprecated.